### PR TITLE
fix: Clear session when returning to dashboard after completing round

### DIFF
--- a/src/pages/Study.jsx
+++ b/src/pages/Study.jsx
@@ -357,6 +357,11 @@ const Study = () => {
   };
 
   const handleBackToDashboard = async () => {
+    // Clear saved session state when returning to dashboard
+    if (user) {
+      await clearStudySessionState(user.uid, deckId);
+    }
+
     // Calculate and save active study duration
     let finalActiveTime = activeTimeMs;
     if (isActive) {


### PR DESCRIPTION
- Clear saved session state in handleBackToDashboard()
- Ensures button shows "Review" (not "Continue") after completing a deck
- Session properly cleaned up when user finishes studying and returns to dashboard